### PR TITLE
Fix absURL vendor/google/fonts/ #113

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -307,7 +307,7 @@ consectetuer adipiscing
 
   # used in layouts/partials/head.html
   # use true for https://themes.gohugo.io/hugo-theme-w3css-basic
-  fontsUseGoogleApis=true
+  fontsUseGoogleApis=false
 
   # Google Maps API key
   # get our own: https://developers.google.com/maps/documentation/javascript/adding-a-google-map#key

--- a/layouts/partials/head.fonts.local.style.html
+++ b/layouts/partials/head.fonts.local.style.html
@@ -5,52 +5,52 @@
   font-family: 'Ubuntu Mono';
   font-style: italic;
   font-weight: 400;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Mono Italic'), local('UbuntuMono-Italic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-italic.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-mono-regular - latin */
 @font-face {
   font-family: 'Ubuntu Mono';
   font-style: normal;
   font-weight: 400;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Mono'), local('UbuntuMono-Regular'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-regular.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-mono-700 - latin */
 @font-face {
   font-family: 'Ubuntu Mono';
   font-style: normal;
   font-weight: 700;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Mono Bold'), local('UbuntuMono-Bold'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-mono-700italic - latin */
 @font-face {
   font-family: 'Ubuntu Mono';
   font-style: italic;
   font-weight: 700;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Mono Bold Italic'), local('UbuntuMono-BoldItalic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-mono-v7-latin-700italic.svg#UbuntuMono"}}') format('svg'); /* Legacy iOS */
 }
 
 
@@ -59,104 +59,104 @@
   font-family: 'Ubuntu';
   font-style: italic;
   font-weight: 400;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Italic'), local('Ubuntu-Italic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-regular - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: normal;
   font-weight: 400;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Regular'), local('Ubuntu-Regular'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-regular.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-regular.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-300 - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: normal;
   font-weight: 300;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Light'), local('Ubuntu-Light'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-300italic - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: italic;
   font-weight: 300;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Light Italic'), local('Ubuntu-LightItalic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-300italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-300italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-500 - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: normal;
   font-weight: 500;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Medium'), local('Ubuntu-Medium'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-500italic - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: italic;
   font-weight: 500;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Medium Italic'), local('Ubuntu-MediumItalic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-500italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-500italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-700 - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: normal;
   font-weight: 700;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Bold'), local('Ubuntu-Bold'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 /* ubuntu-700italic - latin */
 @font-face {
   font-family: 'Ubuntu';
   font-style: italic;
   font-weight: 700;
-  src: url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.eot"}}'); /* IE9 Compat Modes */
+  src: url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.eot"}}'); /* IE9 Compat Modes */
   src: local('Ubuntu Bold Italic'), local('Ubuntu-BoldItalic'),
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.woff"}}') format('woff'), /* Modern Browsers */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
-       url('{{ relURL "vendor/google/fonts/ubuntu-v11-latin-700italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.eot?#iefix"}}') format('embedded-opentype'), /* IE6-IE8 */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.woff2"}}') format('woff2'), /* Super Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.woff"}}') format('woff'), /* Modern Browsers */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.ttf"}}') format('truetype'), /* Safari, Android, iOS */
+       url('{{ absURL "vendor/google/fonts/ubuntu-v11-latin-700italic.svg#Ubuntu"}}') format('svg'); /* Legacy iOS */
 }
 
 </style>


### PR DESCRIPTION
https://themes.gohugo.io/theme/hugo-theme-w3css-basic/
was showing 
url('/vendor/google/fonts/
instead of
https://themes.gohugo.io/theme/hugo-theme-w3css-basic/vendor/fonts

fix:
head.fonts.local.style.html
url('{{ relURL "vendor/google/fonts/
=>
url('{{ absURL "vendor/google/fonts/
