### PR TITLE
Fix #200; avoid error if no theme config params are given

### DIFF
--- a/layouts/partials/header.nav.html
+++ b/layouts/partials/header.nav.html
@@ -1,12 +1,17 @@
 {{- if or $.Site.Params.debug (findRE `\bhtml-comment\b` $.Site.Params.traceFlags) }}
   {{ `<!-- partials/header.nav.html -->` | safeHTML }}
 {{- end}}
+{{- $.Scratch.Set `smallDispMenuMaxCharsDefault` 99 }}
+{{- if isset $.Site.Params (lower `menuConfig` ) }}
 {{- if isset $.Site.Params.menuConfig (lower `smallDispMenuMaxChars` ) }}
 {{- $.Scratch.Set `smallDispMenuLower` 1 }}
 {{- else}}
 {{- $.Scratch.Set `smallDispMenuLower` `` }}
 {{- end}}
-{{- $.Scratch.Set `smallDispMenuMaxChars`    ($.Site.Params.menuConfig.smallDispMenuMaxChars  | default 99) }}
+{{- $.Scratch.Set `smallDispMenuMaxChars`    ($.Site.Params.menuConfig.smallDispMenuMaxChars  | default ($.Scratch.Get `smallDispMenuMaxCharsDefault`) ) }}
+{{- else}}
+{{- $.Scratch.Set `smallDispMenuMaxChars`    ($.Scratch.Get `smallDispMenuMaxCharsDefault`) }}
+{{- end}}
 
 <div class='w3-bar w3-hide-small {{ default `w3-theme-dark` ($.Site.Param `colorHeaderNav`)}} '>
   {{- if or $.Site.Params.debug (findRE `\bhtml-comment\b` $.Site.Params.traceFlags) }}

--- a/layouts/partials/main.taxonomy.current.html
+++ b/layouts/partials/main.taxonomy.current.html
@@ -2,7 +2,7 @@
   {{ `<!-- partials/main.taxonomy.current.html -->` | safeHTML }}
 {{- end}}
 <div class="w3-right-align ">
-{{- if isset .Params (lower `categories` ) }}
+{{- if .Params.categories  }}
 {{- if not (eq (len .Params.categories) 0) }}
 {{- if ne (index .Params.categories 0) `` }}
     <a href='{{ `/categories` | relURL }}{{ if $.Site.Params.uglyURLs }}{{$.Site.Params.uglyUrl}}{{ end }}' class="taxonomy-button w3-button"><i class="far fa-folder-open"></i></a>
@@ -12,7 +12,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if isset .Params (lower `tags` ) }}
+{{- if .Params.tags }}
 {{- if not (eq (len .Params.tags) 0) }}
 {{- if ne (index .Params.tags 0) `` }}
    <a href='{{ `/tags` | relURL }}{{ if $.Site.Params.uglyURLs }}{{$.Site.Params.uglyUrl}}{{ end }}' class="taxonomy-button w3-button"><i class="fas fa-tags"></i></a>


### PR DESCRIPTION
This is likely one of the most configurable themes (with regards to the count of config parameters). But when a users provides this theme with a basically "empty" config - no error should occur.
This PR fixes 2
```
at <len .Params.tags>: error calling len: len of untyped nil
```

errors.

>  (main page won't render, only single posts):

Yes this is intentionally. Each part of the main page is configurable - this includes it's presence. By default each part is absent (except the bottom line).

See https://github.com/it-gro/hugo-theme-w3css-basic#frontpage how the parts of the main page (I named it front) can be enabled (by giving *enable = true*)

The idea is to use the given exampleSite config.toml as starting point. As described in https://github.com/it-gro/hugo-theme-w3css-basic#configuration

Thx for raising this bug!
Kind Regards


